### PR TITLE
Fix #25: switch to fHasLuxSi1133

### DIFF
--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -128,7 +128,9 @@ public:
                 // platform has 1MB or 2MB FLASH
                 fHasFlash = 1 << 13,
                 // platform has SI 1113 Lux sensor
-                fHasLuxSi1113 = 1 << 14,
+                fHasLuxSi1133 = 1 << 14,
+		// [[deprecated("use fHasLuxSi1133")]]
+		fHasLuxSi1113 = fHasLuxSi1133,
 		// platform has BME680
 		fHasBme680 = 1 << 15,
 		// platform has RS485 on Serial1, with A3 

--- a/src/lib/stm32/CatenaStm32_gk_PlatformHierarchy.cpp
+++ b/src/lib/stm32/CatenaStm32_gk_PlatformHierarchy.cpp
@@ -74,7 +74,7 @@ const CATENA_PLATFORM gkPlatformCatena4550 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasFlash,
 	};
@@ -87,7 +87,7 @@ const CATENA_PLATFORM gkPlatformCatena4551 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasFlash,
 	};
@@ -100,7 +100,7 @@ const CATENA_PLATFORM gkPlatformCatena4551_m101 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasFlash |
 		CatenaBase::fM101
@@ -114,7 +114,7 @@ const CATENA_PLATFORM gkPlatformCatena4551_m102 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasSoilProbe |
 		CatenaBase::fHasWaterOneWire |
@@ -129,7 +129,7 @@ const CATENA_PLATFORM gkPlatformCatena4551_m103 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasSoilProbe |
 		CatenaBase::fHasSolarPanel |
@@ -145,7 +145,7 @@ const CATENA_PLATFORM gkPlatformCatena4551_m104 =
 		CatenaBase::fHasLoRa |
 		CatenaBase::fHasTtnNycLoRa |
 		CatenaBase::fHasBme280 |
-		CatenaBase::fHasLuxSi1113 |
+		CatenaBase::fHasLuxSi1133 |
 		CatenaBase::fHasFRAM |
 		CatenaBase::fHasSoilProbe |
 		CatenaBase::fHasWaterOneWire |


### PR DESCRIPTION
Add new symbol `fHasLuxSi1133`, and change all internal uses. Retain `fHasLuxSi1113` as a synonym for `fHasluxSi1133`.