### PR TITLE
Fix #170: Updated the size of the standard key for BME680

### DIFF
--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -18,7 +18,7 @@ Copyright notice:
                 Ithaca, NY  14850
 
         An unpublished work.  All rights reserved.
-        
+
         This file is released under terms of the accompanying LICENSE file.
 
 Author:
@@ -91,7 +91,7 @@ Revision history:
 #define CATENA_ARDUINO_PLATFORM_VERSION_CALC(major, minor, patch, local)	\
 	(((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define	CATENA_ARDUINO_PLATFORM_VERSION	CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 14, 0, 63)	/* v0.14.0.63 */
+#define	CATENA_ARDUINO_PLATFORM_VERSION	CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 14, 0, 70)	/* v0.14.0.70 */
 
 #define	CATENA_ARDUINO_PLATFORM_VERSION_GET_MAJOR(v)	\
 	(((v) >> 24u) & 0xFFu)
@@ -188,7 +188,7 @@ public:
 		fHasLuxSi1113 = fHasLuxSi1133,
 		// platform has BME680
 		fHasBme680 = 1 << 15,
-		// platform has RS485 on Serial1, with A3 
+		// platform has RS485 on Serial1, with A3
 		// controlling power and A4 controlling TXE
 		fHasRS485 = 1 << 16,
 		// platform uses A2 to control VOUT1 (on terminals)

--- a/src/lib/Catena_FramStorage.cpp
+++ b/src/lib/Catena_FramStorage.cpp
@@ -18,10 +18,10 @@ Copyright notice:
 		Ithaca, NY  14850
 
 	An unpublished work.  All rights reserved.
-	
+
 	This file is proprietary information, and may not be disclosed or
 	copied without the prior permission of MCCI Corporation.
- 
+
 Author:
 	Terry Moore, MCCI Corporation	March 2017
 
@@ -46,7 +46,7 @@ using namespace McciCatena;
 
 const MCCIADK_GUID_WIRE McciCatena::cFramStorage::skFramGuid = GUID_FRAM_CATENA_V1(WIRE);
 
-const cFramStorage::StandardItem 
+const cFramStorage::StandardItem
 McciCatena::cFramStorage::vItemDefs[cFramStorage::kMAX] =
         {
         cFramStorage::StandardItem(kHeader, sizeof(uint32_t), /* number */ true),
@@ -66,8 +66,8 @@ McciCatena::cFramStorage::vItemDefs[cFramStorage::kMAX] =
         cFramStorage::StandardItem(kBootCount, sizeof(uint32_t), /* number */ true),
         cFramStorage::StandardItem(kOperatingFlags, sizeof(uint32_t), /* number */ true),
 
-	/* the size field should match BSEC_MAX_STATE_BLOB_SIZE, whcich is 65 */
-	cFramStorage::StandardItem(kBme680Cal, 65, /* number */ false),
+	/* the size field should match BSEC_MAX_STATE_BLOB_SIZE, whcich is 139 */
+	cFramStorage::StandardItem(kBme680Cal, 139, /* number */ false),
         };
 
 
@@ -162,13 +162,13 @@ Function:
 	Check whether this object is identified by given GUID.
 
 Definition:
-	public: bool 
+	public: bool
 		McciCatena::cFramStorage::Object::matchesGuid(
 			const MCCIADK_GUID_WIRE &guid
 			) const;
 
 Description:
-	Simply compares the GUID to the one in the object. 
+	Simply compares the GUID to the one in the object.
 
 Returns:
 	true for equality.
@@ -183,7 +183,7 @@ Notes:
 
 */
 
-bool 
+bool
 McciCatena::cFramStorage::Object::matchesGuid(
 	const MCCIADK_GUID_WIRE &guid
 	) const


### PR DESCRIPTION
The value for size of the standard key for BME680 is updated to 139 from 65 with reference to BSEC v1.4.7.3.