### PR TITLE
Removed use of Adafruit_FRAM_I2C in Catena_Fram2k.h

### DIFF
--- a/src/Catena_Fram2k.h
+++ b/src/Catena_Fram2k.h
@@ -40,8 +40,8 @@ Revision history:
 # include "Catena_Fram.h"
 #endif
 
-#ifndef _ADAFRUIT_FRAM_I2C_H_
-# include <Adafruit_FRAM_I2C.h>
+#ifndef _CATENA_MB85RC64TA_H_
+# include "Catena_Mb85rc64ta.h"
 #endif
 
 /****************************************************************************\
@@ -84,7 +84,7 @@ public:
 
 protected:
 private:
-	Adafruit_FRAM_I2C	m_hw;
+	Catena_Mb85rc64ta	m_hw;
 	};
 
 }; // namespace McciCatena


### PR DESCRIPTION
Hello,

I've just begun using the Catena 4610 and ran into some issues when attempting to compile your examples.
Catena_Fram2k is attempting to use Adafruit_FRAM_I2C with the wrong function names and parameters, which Adafruit_FRAM_I2C has never had. I swapped the adafruit lib with Catena_Mb85rc64ta and the examples compile successfully now. Not entirely sure that the use of Catena_Mb85rc64ta will work during runtime, so I'll leave that up to you. 

-Kent