### PR TITLE
Add Generic Application Block to FRAM Map

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This library provides a simple-to-use framework for taking advantage of many of 
 
 _Apologies_: This document is a work in progress, and is published in this intermediate form in hopes that it will still be better than nothing.
 
-[![GitHub release](https://img.shields.io/github/release/mcci-catena/Catena-Arduino-Platform.svg)](https://github.com/mcci-catena/Catena-Arduino-Platform/releases/latest) [![GitHub commits](https://img.shields.io/github/commits-since/mcci-catena/Catena-Arduino-Platform/latest.svg)](https://github.com/mcci-catena/Catena-Arduino-Platform/compare/v0.18.0...master) [![Build Status](https://travis-ci.com/mcci-catena/Catena-Arduino-Platform.svg?branch=master)](https://travis-ci.com/mcci-catena/Catena-Arduino-Platform)
+[![GitHub release](https://img.shields.io/github/release/mcci-catena/Catena-Arduino-Platform.svg)](https://github.com/mcci-catena/Catena-Arduino-Platform/releases/latest) [![GitHub commits](https://img.shields.io/github/commits-since/mcci-catena/Catena-Arduino-Platform/latest.svg)](https://github.com/mcci-catena/Catena-Arduino-Platform/compare/v0.18.1...master) [![Build Status](https://travis-ci.com/mcci-catena/Catena-Arduino-Platform.svg?branch=master)](https://travis-ci.com/mcci-catena/Catena-Arduino-Platform)
 
 <!-- markdownlint-disable MD033 -->
 <!-- markdownlint-capture -->
@@ -1375,6 +1375,8 @@ This sketch demonstrates the use of the Catena FSM class to implement the `Turns
 | [`catena-mcciadk`](https://github.com/mcci-catena/Catena-mcciadk) | 0.2.1 | 0.1.2 | Needed for miscellaneous definitions |
 
 ## Library Release History
+- v0.18.1 includes the following changes.
+  - [#247](https://github.com/mcci-catena/Catena-Arduino-Platform/pull/247) Add a generic application block to FRAM map
 
 - v0.18.0 includes the following changes.
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=MCCI Catena Arduino Platform
-version=0.18.0
+version=0.18.1
 author=Terry Moore, ChaeHee Won, Sungjoon Park
 maintainer=MCCI Corporation <techsupport@mcci.com>
 sentence=Arduino library for MCCI Catena 44xx, 45xx, 46xx and 48xx systems.

--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -55,7 +55,7 @@ Author:
 #define CATENA_ARDUINO_PLATFORM_VERSION_CALC(major, minor, patch, local)        \
         (((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 18, 0, 0)      /* v0.18.0.0 */
+#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 18, 1, 0)      /* v0.18.0.0 */
 
 #define CATENA_ARDUINO_PLATFORM_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/Catena_FramStorage.h
+++ b/src/Catena_FramStorage.h
@@ -47,9 +47,13 @@ public:
                 kBootCount = 14,
                 kOperatingFlags = 15,
                 kBme680Cal = 16,
+                kAppConf = 17,
                 // when you add something, also update McciCatena::cFramStorage::vItemDefs[]!
                 kMAX
                 };
+
+        /* client should beware of MaxAppConfSize using the kAppConf key*/
+        const static unsigned int MaxAppConfSize = 64;
 
         class StandardItem
                 {

--- a/src/lib/Catena_FramStorage.cpp
+++ b/src/lib/Catena_FramStorage.cpp
@@ -66,8 +66,8 @@ McciCatena::cFramStorage::vItemDefs[cFramStorage::kMAX] =
         cFramStorage::StandardItem(kBootCount, sizeof(uint32_t), /* number */ true),
         cFramStorage::StandardItem(kOperatingFlags, sizeof(uint32_t), /* number */ true),
 
-	/* the size field should match BSEC_MAX_STATE_BLOB_SIZE, whcich is 139 */
-	cFramStorage::StandardItem(kBme680Cal, 139, /* number */ false),
+        /* the size field should match BSEC_MAX_STATE_BLOB_SIZE, which is 139 */
+        cFramStorage::StandardItem(kBme680Cal, 139, /* number */ false),
         };
 
 

--- a/src/lib/Catena_FramStorage.cpp
+++ b/src/lib/Catena_FramStorage.cpp
@@ -68,6 +68,7 @@ McciCatena::cFramStorage::vItemDefs[cFramStorage::kMAX] =
 
         /* the size field should match BSEC_MAX_STATE_BLOB_SIZE, which is 139 */
         cFramStorage::StandardItem(kBme680Cal, 139, /* number */ false),
+        cFramStorage::StandardItem(kAppConf, cFramStorage::MaxAppConfSize, false)
         };
 
 


### PR DESCRIPTION
This is intended to allow a user to store more or less arbitrary data an FRAM slot. It would be up to the application layer to derive and determine validity of the data in the block.