### PR TITLE
Revert "update "Fix #253: Use AdcStart() before each ReadAnalog value""

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,13 +1378,9 @@ This sketch demonstrates the use of the Catena FSM class to implement the `Turns
 
 ## 9. Release History
 
-- HEAD includes the following changes.
-
-  - Fix [#253](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/253): add `AdcStart()` before each `AdcGetValue()` to read channel value (version 0.19.0.10).
-
 - v0.19.0 includes the following changes.
 
-  - [#248](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/248) Add interactive command `lorawan configure` to display all the parameters.
+  - [#248](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/248) Add interactive command `lorawan configure` to display all hte parameters.
   
 - v0.18.1 includes the following changes.
   - [#247](https://github.com/mcci-catena/Catena-Arduino-Platform/pull/247) Add a generic application block to FRAM map

--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -55,7 +55,7 @@ Author:
 #define CATENA_ARDUINO_PLATFORM_VERSION_CALC(major, minor, patch, local)        \
         (((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 19, 0, 10)      /* v0.19.0.10 */
+#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 19, 0, 0)      /* v0.19.0.0 */
 
 #define CATENA_ARDUINO_PLATFORM_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)


### PR DESCRIPTION
Reverts mcci-catena/Catena-Arduino-Platform#256. This erroneously mentions #253, but doesn't actually include the changes that were pushed on #254.