### PR TITLE
Fix #253: add AdcStart() before each AdcGetValue()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1378,9 +1378,13 @@ This sketch demonstrates the use of the Catena FSM class to implement the `Turns
 
 ## 9. Release History
 
+- HEAD includes the following changes.
+
+  - Fix [#253](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/253): add `AdcStart()` before each `AdcGetValue()` to read channel value (version 0.19.0.10).
+
 - v0.19.0 includes the following changes.
 
-  - [#248](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/248) Add interactive command `lorawan configure` to display all hte parameters.
+  - [#248](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/248) Add interactive command `lorawan configure` to display all the parameters.
   
 - v0.18.1 includes the following changes.
   - [#247](https://github.com/mcci-catena/Catena-Arduino-Platform/pull/247) Add a generic application block to FRAM map

--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -55,7 +55,7 @@ Author:
 #define CATENA_ARDUINO_PLATFORM_VERSION_CALC(major, minor, patch, local)        \
         (((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 19, 0, 0)      /* v0.19.0.0 */
+#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 19, 0, 10)      /* v0.19.0.10 */
 
 #define CATENA_ARDUINO_PLATFORM_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
+++ b/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
@@ -163,7 +163,7 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 		ADC1->SMPR = ADC_SMPR_SMPR;
 		ADC->CCR = ADC_CCR_VREFEN;
 
-		/* start ADC, which will take 2 readings */
+		/* start ADC, before each readings */
 		AdcStart();
 
 		fStatusOk = AdcGetValue(&vRef);
@@ -171,7 +171,10 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 			{
 			*pValue = 5;
 			if (Channel != STM32L0_ADC_CHANNEL_VREFINT)
+				{
+				AdcStart();
 				fStatusOk = AdcGetValue(&vChannel);
+				}
 			else
 				vChannel = vRef;
 			}
@@ -217,7 +220,7 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 		vRefInt_cal = (*pVrefintCal * 3000 + 1) / (4096 / 4);
 
 		vResult = vChannel * Multiplier;
-	
+
 		vResult = vResult * vRefInt_cal / vRef;
 		// remove the factor of 4, and round
 		*pValue = (vResult + 2) >> 2;

--- a/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
+++ b/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
@@ -163,7 +163,7 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 		ADC1->SMPR = ADC_SMPR_SMPR;
 		ADC->CCR = ADC_CCR_VREFEN;
 
-		/* start ADC, before each readings */
+		/* start ADC, before each reading */
 		AdcStart();
 
 		fStatusOk = AdcGetValue(&vRef);

--- a/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
+++ b/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
@@ -222,7 +222,7 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 		vRefInt_cal = (*pVrefintCal * 3000 + 1) / (4096 / 4);
 
 		vResult = vChannel * Multiplier;
-
+	
 		vResult = vResult * vRefInt_cal / vRef;
 		// remove the factor of 4, and round
 		*pValue = (vResult + 2) >> 2;

--- a/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
+++ b/src/lib/stm32/stm32l0/CatenaStm32L0_ReadAnalog.cpp
@@ -176,7 +176,9 @@ bool McciCatena::CatenaStm32L0_ReadAnalog(
 				fStatusOk = AdcGetValue(&vChannel);
 				}
 			else
+				{
 				vChannel = vRef;
+				}
 			}
 
 		if (fStatusOk)


### PR DESCRIPTION
This pull-reuqest includes:

- ADC code fix for ReadAnalog failure #253 
- Update in Version number (last field)
- Update in Revision history in README