### PR TITLE
fix: updated the read/write offset with buffer size or allowed buffer size

### DIFF
--- a/src/lib/Catena_Mb85rc64ta.cpp
+++ b/src/lib/Catena_Mb85rc64ta.cpp
@@ -250,6 +250,7 @@ size_t Catena_Mb85rc64ta::write(
 		    	{
 			nBuffer -= nThis;
 			pBuffer += nThis;
+			framAddr += nThis;
 		    	}
 		else
 			// error!
@@ -353,12 +354,13 @@ size_t Catena_Mb85rc64ta::read(
 				// error
 				break;
 				}
-			while (nBuffer > 0)
+			while (nRead > 0)
 				{
 				*pBuffer++ = this->m_pWire->read();
 				--nBuffer;
+				--nRead;
 				}
-			framAddr += nRead;
+			framAddr += nThis;
 			}
 		else
 			// error


### PR DESCRIPTION
Update the offset with the received buffer size (if less than 32 bytes) or with the limited buffer size (32 bytes) in `Catena_Mb85rc64ta::read()` and `write()`.