### PR TITLE
Fix #273: clamp negative light values from Si1133 to zero.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1431,6 +1431,10 @@ This sketch demonstrates the use of the Catena FSM class to implement the `Turns
 
 ## Release History
 
+- HEAD includes the following changes
+
+  - fix [#273](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/273): in very low light conditions, with 24-bit measurements, Si1133 can generate negative light readings. Detect such values and force to zero (version 0.20.0.10).
+
 - v0.20.0 includes the following changes.
 
   - Fix [#268](https://github.com/mcci-catena/Catena-Arduino-Platform/issues/268): adds support to the new board Catena 4802 (version 0.19.0.40).

--- a/src/CatenaBase.h
+++ b/src/CatenaBase.h
@@ -55,7 +55,7 @@ Author:
 #define CATENA_ARDUINO_PLATFORM_VERSION_CALC(major, minor, patch, local)        \
         (((major) << 24u) | ((minor) << 16u) | ((patch) << 8u) | (local))
 
-#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 20, 0, 0)      /* v0.20.0.0 */
+#define CATENA_ARDUINO_PLATFORM_VERSION CATENA_ARDUINO_PLATFORM_VERSION_CALC(0, 20, 0, 10)      /* v0.20.0.10 */
 
 #define CATENA_ARDUINO_PLATFORM_VERSION_GET_MAJOR(v)    \
         (((v) >> 24u) & 0xFFu)

--- a/src/lib/Catena_Si1133.cpp
+++ b/src/lib/Catena_Si1133.cpp
@@ -404,6 +404,12 @@ bool Catena_Si1133::readMultiChannelData(uint32_t *pChannelData, uint32_t nChann
 
 		channelData |= this->m_pWire->read() << 8;
 		channelData |= this->m_pWire->read();
+
+		if (channelData >= 0x800000)
+			{
+			channelData = 0;
+			}
+
 		*pChannelData = channelData;
 		}
 	return true;


### PR DESCRIPTION
There's an offset-removal stage in the Si1133. Occasionally, due to noise or drift, offset measurement will generate a value larger then the actual measurement; this results in a "negative" light value. Seems only to happen in 24-bit mode. This fix detects negative light values and clamps them to zero.