### PR TITLE
Fix dependency name

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -9,4 +9,4 @@ architectures=samd,stm32
 url=https://github.com/mcci-catena/Catena-Arduino-Platform
 dot_a_linkage=true
 includes=Catena.h
-depends=MCCI LoRaWAN LMIC library,MCCI Arduino LoRaWAN Library,MCCI Arduino Development Kit ADK,MCCI FRAM I2C,MCCI LTR 329ALS
+depends=MCCI LoRaWAN LMIC library,MCCI Arduino LoRaWAN Library,MCCI Arduino Development Kit ADK,MCCI FRAM I2C,MCCI LTR-329ALS


### PR DESCRIPTION
Fix the dependency name of the light sensor dependency from `MCCI LTR 329ALS` to `MCCI LTR-329ALS` (see [here](https://github.com/mcci-catena/mcci_ltr_329als/blob/031e6bbb84149a61d6053469bf0fec175a70db6a/library.properties#L1))